### PR TITLE
HTTP Style Guide sweep

### DIFF
--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -721,13 +721,13 @@ require the test to run for much longer to deliver the same results.
 The server MUST respond to 4 URLs:
 
 1. A "small" URL/response:
-The server must respond with a status code of 200 and 1 byte of content.
+The server must respond with a status code of 200 (OK) and 1 byte of content.
 The actual message content is irrelevant.
 The server SHOULD specify the content-type as application/octet-stream.
 The server SHOULD minimize the size, in bytes, of the response fields that are encoded and sent on the wire.
 
 2. A "large" URL/response:
-The server must respond with a status code of 200 and content size of at least 8GB.
+The server must respond with a status code of 200 (OK) and content size of at least 8GB.
 The server SHOULD specify the content-type as application/octet-stream.
 The content can be larger, and may need to grow as network speeds increases over time.
 The actual message content is irrelevant.

--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -682,14 +682,14 @@ probing connections in the same way.
 The responsiveness measurement is built upon a foundation of standard protocols:
 IP, TCP, TLS, HTTP/2.
 On top of this foundation, a minimal amount of new "protocol" is defined,
-merely specifying the URLs that used for GET and PUT in the process of
+merely specifying the URLs that used for GET and POST in the process of
 executing the test.
 
 Both the client and the server MUST support HTTP/2 over TLS.
-The client MUST be able to send a GET request and a POST.
+The client MUST be able to send a request with a GET or POST method.
 The server MUST be able to respond to both of these
 HTTP commands.
-The server MUST have the ability to provide content upon a GET request.
+The server MUST have the ability to respond to a GET request with content.
 The server MUST use a packet scheduling algorithm that minimizes internal queueing
 to avoid affecting the client's measurement.
 

--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -723,12 +723,12 @@ The server MUST respond to 4 URLs:
 1. A "small" URL/response:
 The server must respond with a status code of 200 (OK) and 1 byte of content.
 The actual message content is irrelevant.
-The server SHOULD specify the content-type as application/octet-stream.
+The server SHOULD specify the Content-Type header field with the media type "application/octet-stream".
 The server SHOULD minimize the size, in bytes, of the response fields that are encoded and sent on the wire.
 
 2. A "large" URL/response:
 The server must respond with a status code of 200 (OK) and content size of at least 8GB.
-The server SHOULD specify the content-type as application/octet-stream.
+The server SHOULD specify the Content-Type header field with the media type "application/octet-stream".
 The content can be larger, and may need to grow as network speeds increases over time.
 The actual message content is irrelevant.
 The client will probably never completely download the object,

--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -519,7 +519,7 @@ goodput stability has been achieved, responsiveness probes will be transmitted
 until responsiveness stability is reached.
 
 We consider both goodput and responsiveness to be stable when the standard deviation
-of the moving averages of the responsiveness calculated in the most-recent MAD intervals is within SDT 
+of the moving averages of the responsiveness calculated in the most-recent MAD intervals is within SDT
 (Standard Deviation Tolerance - default to 5%) of the moving average calculated in the most-recent ID.
 
 The following algorithm reaches working conditions of a network
@@ -721,23 +721,23 @@ require the test to run for much longer to deliver the same results.
 The server MUST respond to 4 URLs:
 
 1. A "small" URL/response:
-The server must respond with a status code of 200 and 1 byte in the body.
+The server must respond with a status code of 200 and 1 byte of content.
 The actual message content is irrelevant.
 The server SHOULD specify the content-type as application/octet-stream.
 The server SHOULD minimize the size, in bytes, of the response fields that are encoded and sent on the wire.
 
 2. A "large" URL/response:
-The server must respond with a status code of 200 and a body size of at least 8GB.
+The server must respond with a status code of 200 and content size of at least 8GB.
 The server SHOULD specify the content-type as application/octet-stream.
-The body can be bigger, and may need to grow as network speeds increases over time.
+The content can be larger, and may need to grow as network speeds increases over time.
 The actual message content is irrelevant.
 The client will probably never completely download the object,
 but will instead close the connection after reaching working condition
 and making its measurements.
 
 3. An "upload" URL/response:
-The server must handle a POST request with an arbitrary body size.
-The server should discard the payload.
+The server must handle a POST request with an arbitrary content size.
+The server should discard the content.
 The actual POST message content is irrelevant.
 The client will probably never completely upload the object,
 but will instead close the connection after reaching working condition

--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -49,6 +49,10 @@ author:
     org: University of Cincinnati
     email: hawkinwh@ucmail.uc.edu
 
+normative:
+  RFC9110:
+    display: HTTP
+
 informative:
   Bufferbloat:
     author:
@@ -158,6 +162,9 @@ Finally, we abbreviate the unit to "RPM", a wink to the
 
 This document defines an algorithm for the "Responsiveness Test"
 that explicitly measures responsiveness under working conditions.
+
+This document imports terminology and concepts from {{HTTP}}, such as requests
+and response header fields and content.
 
 # Design Constraints
 


### PR DESCRIPTION
A series of commits with tweaks to better align with https://httpwg.org/admin/editors/style-guide.

The only major thing here is importing HTTP as a normative reference, which seems important since it relates to normative text in the document.

