### PR TITLE
Clarified JSON object syntax and DNS-SD advertising

### DIFF
--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -870,7 +870,8 @@ the format of the resource is as specified below:
 The fields can appear in any order.
 
 The content of the "version" field SHALL be "1".
-Integer values greater than "1" are reserved for future versions of this protocol.
+Integer values greater than "1" are reserved
+for possible use in future updates to this protocol.
 
 The content of the "large\_download\_url", "small\_download\_url", and "upload_url"
 SHALL all be validly formatted "http" or "https" URLs.
@@ -902,6 +903,18 @@ to deliver low-delay HTTP responses and some have not,
 it can be useful to be able to measure the responsiveness of different
 servers with different configurations to see how they compare
 when handling identical HTTP GET and POST requests.
+
+Servers implementing the current version of this specification
+SHOULD NOT include any keys in the JSON configuration information
+other than those documented here.
+Future updates to this specification may define additional keys
+in the JSON configuration information.
+To allow for these future backwards-compatible updates,
+clients implementing the current version of this specification
+MUST silently ignore any unrecognized keys in the
+JSON configuration information they receive,
+and MUST process the required keys as documented here,
+behaving as if the unrecognized keys were not present.
 
 ## DNS-Based Service Discovery for Test Server Discovery
 

--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -853,7 +853,7 @@ The URI scheme is "https" and the application name is "nq"
 No additional path components, query strings or fragments are valid
 for this well-known URI.
 The media type of the resource at the well-known URI is "application/json" and
-the format of the resource is as specified below:
+the format of the resource is a valid JSON object as specified below:
 
 ~~~
 {
@@ -878,9 +878,13 @@ SHALL all be validly formatted "http" or "https" URLs.
 All three URLs MUST all contain the same \<host\> part so that they are
 eligible to be multiplexed onto the same TCP or QUIC connection.
 
-The "version" field and the three URLs are REQUIRED.
+The "version" field and the three URLs are mandatory
+and each MUST appear exactly once in the JSON object.
+If any of these fields are missing or appear more than once,
+the configuration information is invalid and the entire JSON object MUST be ignored.
 
-The "test\_endpoint" field is OPTIONAL.
+The "test\_endpoint" field is OPTIONAL,
+and if present MUST appear exactly once in the JSON object.
 If present, then for the purpose of determining the IP address to which it should
 connect the test client MUST ignore the \<host\> part in the URLs and instead
 connect to one of the IP addresses indicated by the "test\_endpoint" field,
@@ -890,13 +894,14 @@ The test client then sends HTTP GET and POST requests
 (as determined by the test procedure)
 to the host indicated by the "test\_endpoint" field,
 forming its HTTP requests using the \<host\> and \<path\> from the specified URLs.
-In other words, the test client operates as if it were simply
+In other words, when the "test\_endpoint" field is present
+the test client operates as if it were simply
 using the specified URLs directly, except that it behaves
 as if it had a local (e.g., “/etc/hosts”) entry overriding the
 IP address(es) of the \<host\> given in the URLs to be the
 IP address(es) of the "test\_endpoint" hostname instead.
 In the case of a large web site served by multiple load-balanced
-servers, this gives the administrator more precise control over
+servers, this feature gives the administrator more precise control over
 which of those servers are used for responsiveness testing.
 In a situation where some of a site’s servers have been configured
 to deliver low-delay HTTP responses and some have not,
@@ -905,29 +910,27 @@ servers with different configurations to see how they compare
 when handling identical HTTP GET and POST requests.
 
 Servers implementing the current version of this specification
-SHOULD NOT include any keys in the JSON configuration information
+SHOULD NOT include any names in the JSON configuration information
 other than those documented here.
-Future updates to this specification may define additional keys
+Future updates to this specification may define additional names
 in the JSON configuration information.
 To allow for these future backwards-compatible updates,
 clients implementing the current version of this specification
-MUST silently ignore any unrecognized keys in the
+MUST silently ignore any unrecognized names in the
 JSON configuration information they receive,
-and MUST process the required keys as documented here,
-behaving as if the unrecognized keys were not present.
+and MUST process the required names as documented here,
+behaving as if the unrecognized names were not present.
 
 ## DNS-Based Service Discovery for Test Server Discovery
 
 To further aid the test client in discovering Responsiveness Test Servers,
 organizations or devices offering Responsiveness Test Servers
 MAY advertise their availability using DNS-Based Service Discovery {{RFC6763}}
-over Multicast DNS {{RFC6762}} or conventional unicast DNS {{RFC1034}}.
-
-The Responsiveness Test Service instances should advertise
+over Multicast DNS {{RFC6762}} or conventional unicast DNS {{RFC1034}},
 using the service type {{RFC6335}} "_nq._tcp".
 
 When advertising over Multicast DNS, typically the device offering
-the test service also advertises its own Multicast DNS records.
+the test service generally advertises its own Multicast DNS records.
 
 When advertising over unicast DNS, population of the appropriate
 DNS zone with the relevant unicast discovery records can be performed
@@ -994,11 +997,11 @@ We also thank Greg White, Lucas Pardue, Sebastian Moeller, Rich Brown, Erik Auer
 
 # Apache Traffic Server Example Configurations
 
-Apache Traffic Server starting at version 9.1.0 supports configuration as a responsiveness
-server. It requires the generator and the statichit plugin.
+Apache Traffic Server starting at version 9.1.0 supports configuration as a
+Responsiveness Test Server. It requires the generator and the statichit plugin.
 
-This section shows fragments of sample server configurations to host a responsiveness
-measurement endpoint.
+This section shows fragments of sample server configurations to host a
+Responsiveness Test Server.
 
 ## Single Server Configuration
 

--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -763,7 +763,7 @@ mean that the network between client and cable modem is the problem (as
 outlined in the above previous paragraphs).
 
 
-# Responsiveness Test Server API
+# Responsiveness Test Server
 
 The responsiveness measurement is built upon a foundation of standard protocols:
 IP, TCP, TLS, HTTP/2.
@@ -793,7 +793,7 @@ The server SHOULD specify the Content-Type header field with the media type "app
 The content can be larger, and may need to grow as network speeds increases over time.
 The actual message content is irrelevant.
 The client will probably never completely download the object,
-but will instead close the connection after reaching working condition
+but will instead close the connection after reaching working conditions
 and making its measurements.
 
 3. An "upload" URL/response:
@@ -801,10 +801,11 @@ The server must handle a POST request with an arbitrary content size.
 The server should discard the content.
 The actual POST message content is irrelevant.
 The client will probably never completely upload the object,
-but will instead close the connection after reaching working condition
+but will instead close the connection after reaching working conditions
 and making its measurements.
 
-4. A .well-known URL {{RFC8615}} which contains JSON configuration information for
+4. A .well-known URL {{RFC8615}} which serves a JSON object providing
+the three test URLs described above and other configuration information for
 the client to run the test (See {{discovery}}, below.)
 
 The client begins the responsiveness measurement by querying for the JSON {{RFC8259}} configuration.
@@ -846,7 +847,7 @@ or somewhere outside the home.
 
 ## Well-Known Uniform Resource Identifier (URI) For Test Server Discovery
 
-Any organization that wishes to host a Responsiveness Test Server
+An organization or device that hosts a Responsiveness Test Server
 advertises that service using the network quality well-known URI {{RFC8615}}.
 The URI scheme is "https" and the application name is "nq"
 (e.g., https://example.com/.well-known/nq).
@@ -882,6 +883,12 @@ The "version" field and the three URLs are mandatory
 and each MUST appear exactly once in the JSON object.
 If any of these fields are missing or appear more than once,
 the configuration information is invalid and the entire JSON object MUST be ignored.
+If a client implementing the current version of this specification encounters
+a JSON configuration information object where the "version" field is not "1",
+then the client should assume that it is unable
+to safely parse the configuration information object
+(that’s what incrementing the version field indicates)
+and the client MUST ignore the entire JSON object.
 
 The "test\_endpoint" field is OPTIONAL,
 and if present MUST appear exactly once in the JSON object.
@@ -952,7 +959,7 @@ Non-authoritative answer:
 rpm._nq._tcp.obs.crservice = 0 0 443 rpm.obs.cr.
 ~~~
 
-Given those conventional DNS query responses, the client would proceed to access the rpm.obs.cr
+Given those DNS query responses, the client would proceed to access the rpm.obs.cr
 host on port 443 at the .well-known/nq well-known URI to begin the test.
 
 # Security Considerations
@@ -977,14 +984,13 @@ URI suffix: nq
 ## Service Name
 
 IANA has added the following value to the "Service Name and Transport
-Protocol Port Number Registry" in the System Range.  The registry for
-that range requires IETF Review or IESG Approval [RFC6335].
+Protocol Port Number Registry".
 
-Service Name: nq
-Transport Protocol: TCP
-Assignee: {{{Stuart Cheshire}}}
-Contact: {{{Stuart Cheshire}}}
-Description: Network Quality test server endpoint
+Service Name:       nq  
+Transport Protocol: TCP  
+Assignee:           {{{Stuart Cheshire}}}  
+Contact:            {{{Stuart Cheshire}}}  
+Description:        Network Quality test server endpoint
 
 # Acknowledgments
 
@@ -998,7 +1004,7 @@ We also thank Greg White, Lucas Pardue, Sebastian Moeller, Rich Brown, Erik Auer
 # Apache Traffic Server Example Configurations
 
 Apache Traffic Server starting at version 9.1.0 supports configuration as a
-Responsiveness Test Server. It requires the generator and the statichit plugin.
+Responsiveness Test Server, using the generator and the statichit plugin.
 
 This section shows fragments of sample server configurations to host a
 Responsiveness Test Server.


### PR DESCRIPTION
The JSON object syntax was a bit unclear, and had mistakes in the example, like requiring “api/v1” in the URL.