### PR TITLE
Removed current text about why test duration should be short

### DIFF
--- a/draft-ietf-ippm-responsiveness.md
+++ b/draft-ietf-ippm-responsiveness.md
@@ -196,9 +196,6 @@ the difficulty of attaining appropriate measurement conditions,
 diurnal traffic patterns,
 and changing routes.
 
-In order to minimize the effects of these challenges,
-it's best to keep the test duration relatively short.
-
 TCP and UDP traffic, or traffic on ports 80 and 443, may take
 significantly different paths over the network between source and destination
 and be subject to entirely different Quality of Service (QoS) treatment.


### PR DESCRIPTION
The document currently says

```
   There are many challenges to defining measurements of the Internet:
   the dynamic nature of the Internet, the diverse nature of the
   traffic, the large number of devices that affect traffic, the
   difficulty of attaining appropriate measurement conditions, diurnal
   traffic patterns, and changing routes.

   In order to minimize the effects of these challenges, it's best to
   keep the test duration relatively short.
```

The second paragraph reads like a non sequitur to me. For user-convenience I do think we want a version of the test that runs in about ten seconds, but trying to link that to the other “challenges” listed (dynamic nature, diverse nature, large number of devices, diurnal traffic patterns, etc.) seems like a logical stretch.

Suggest deleting the second paragraph for now, and we can re-introduce it when we have a discussion about how long the test should run in order to get stable, repeatable, relevant results.